### PR TITLE
move internal statistics data to constructor

### DIFF
--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -8,7 +8,7 @@ var sauce = require("./util/sauce"),
   Q = require("q"),
   settings = require("./settings.js");
 
-var closeSession = function(client) {
+var closeSession = function (client) {
 
   var deferred = Q.defer();
 
@@ -17,7 +17,7 @@ var closeSession = function(client) {
   return deferred.promise;
 };
 
-var updateSauceStats = function(client, numFailures) {
+var updateSauceStats = function (client, numFailures) {
 
   var deferred = Q.defer();
 
@@ -31,7 +31,7 @@ var updateSauceStats = function(client, numFailures) {
   return deferred.promise;
 };
 
-var emitStartedTest = function(client) {
+var emitStartedTest = function (client) {
   if (settings.isWorker === true) {
     var testName = client.currentTest.module;
 
@@ -47,7 +47,7 @@ var emitStartedTest = function(client) {
   }
 };
 
-var emitFinishedTest = function(client, numFailures) {
+var emitFinishedTest = function (client, numFailures) {
 
   if (settings.isWorker === true) {
     var testName = client.currentTest.module;
@@ -98,6 +98,8 @@ var MagellanBaseTest = function (steps) {
 
 MagellanBaseTest.prototype = {
   before: function (client) {
+    this.failures = [];
+    this.passed = 0;
   },
 
   /*
@@ -139,15 +141,19 @@ MagellanBaseTest.prototype = {
       settings.sessionId = client.sessionId;
     }
 
-    this.failures = this.failures || [];
-    this.passed = (this.passed || 0) + this.results.passed;
+    if (this.results) {
+      // in case we failed in `before`
+      // keep track of failed tests for reporting purposes
+      if (this.results.failed || this.results.errors) {
+        // Note: this.client.currentTest.name is also available to display
+        // the name of the specific step within the test where we've failed.
+        this.failures.push(this.client.currentTest.module);
+      }
 
-    // keep track of failed tests for reporting purposes
-    if (this.results.failed || this.results.errors) {
-      // Note: this.client.currentTest.name is also available to display
-      // the name of the specific step within the test where we've failed.
-      this.failures.push(this.client.currentTest.module);
-    };
+      if (this.results.passed) {
+        this.passed += this.results.passed;
+      }
+    }
     callback();
   },
 
@@ -164,10 +170,15 @@ MagellanBaseTest.prototype = {
       process.removeListener("message", this.handleExternalMessage);
     }
 
+
     emitFinishedTest(client, numFailures)
-      .then(function() { return updateSauceStats(client, numFailures); })
-      .then(function() { return closeSession(client); })
-      .then(function() {
+      .then(function () {
+        return updateSauceStats(client, numFailures);
+      })
+      .then(function () {
+        return closeSession(client);
+      })
+      .then(function () {
         callback();
       });
   }


### PR DESCRIPTION
solves nightwatch process hangs if test fails in `before` step