### PR TITLE
fix nightwatch fake pass if `before` fails

### DIFF
--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -98,6 +98,7 @@ var MagellanBaseTest = function (steps) {
 
 MagellanBaseTest.prototype = {
   before: function (client) {
+    this.isSupposedToFailInBefore = false;
     this.failures = [];
     this.passed = 0;
   },
@@ -179,6 +180,12 @@ MagellanBaseTest.prototype = {
         return closeSession(client);
       })
       .then(function () {
+        if (self.isSupposedToFailInBefore) {
+          // there is a bug in nightwatch that if test fails in `before`, test
+          // would still be reported as passed with a exit code = 0. We'll have 
+          // to let magellan know the test fails in this way 
+          process.exit(100);
+        }
         callback();
       });
   }


### PR DESCRIPTION
There is a bug in nightwatch that if test fails in `before` it would still be reported as passed with a exit code = 0. we'll need a none-zero exit code for this situation. This is the only fake pass patch that we can do quick and dirty for magellan.

@Maciek416 