### PR TITLE
Escape String in RegExp

### DIFF
--- a/lib/assertions/elContainsText.js
+++ b/lib/assertions/elContainsText.js
@@ -2,7 +2,7 @@
 
 var util = require("util"),
   selectorUtil = require("../util/selector"),
-  escapeStringRegexp = require("escapeStringRegexp");
+  escapeRegExp = require("lodash/escapeRegExp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -38,7 +38,7 @@ ElContainsText.prototype.command = function (selector, expectedContainedText) {
 ElContainsText.prototype.assert = function (actual, expected) {
   if (expected === undefined 
     || (actual.indexOf(expected) < 0 
-      && !(new RegExp(escapeStringRegexp(expected)).exec(actual)))) {
+      && !(new RegExp(escapeRegExp(expected)).exec(actual)))) {
     this.fail(actual, expected, this.message, this.failureDetails);
   } else {
     this.pass(actual, expected, this.message);

--- a/lib/assertions/elContainsText.js
+++ b/lib/assertions/elContainsText.js
@@ -1,7 +1,7 @@
 // Assert whether a selector contains a given text
 
 var util = require("util"),
-  selectorUtil = require("../util/selector")
+  selectorUtil = require("../util/selector"),
   escapeStringRegexp = require("escapeStringRegexp");
 
 var BaseElAssertion = require("./base/baseElAssertion");

--- a/lib/assertions/elContainsText.js
+++ b/lib/assertions/elContainsText.js
@@ -1,7 +1,8 @@
 // Assert whether a selector contains a given text
 
 var util = require("util"),
-  selectorUtil = require("../util/selector");
+  selectorUtil = require("../util/selector")
+  escapeStringRegexp = require("escapeStringRegexp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -37,7 +38,7 @@ ElContainsText.prototype.command = function (selector, expectedContainedText) {
 ElContainsText.prototype.assert = function (actual, expected) {
   if (expected === undefined 
     || (actual.indexOf(expected) < 0 
-      && !(new RegExp(expected).exec(actual)))) {
+      && !(new RegExp(escapeStringRegexp(expected)).exec(actual)))) {
     this.fail(actual, expected, this.message, this.failureDetails);
   } else {
     this.pass(actual, expected, this.message);

--- a/lib/assertions/elNotContainsText.js
+++ b/lib/assertions/elNotContainsText.js
@@ -2,7 +2,7 @@
 
 var util = require("util"),
   selectorUtil = require("../util/selector"),
-  escapeStringRegexp = require("escapeStringRegexp");
+  escapeRegExp = require("lodash/escapeRegExp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -36,7 +36,7 @@ ElContainsText.prototype.command = function (selector, expectedContainedText) {
 ElContainsText.prototype.assert = function (actual, expected) {
   if (expected !== undefined 
     && actual.indexOf(expected) < 0 
-    && !(new RegExp(escapeStringRegexp(expected)).exec(actual))) {
+    && !(new RegExp(escapeRegExp(expected)).exec(actual))) {
     this.pass(actual, expected, this.message);
   } else {
     this.fail(actual, expected, this.message, this.failureDetails);

--- a/lib/assertions/elNotContainsText.js
+++ b/lib/assertions/elNotContainsText.js
@@ -1,7 +1,8 @@
 // Assert whether a selector contains a given text
 
 var util = require("util"),
-  selectorUtil = require("../util/selector");
+  selectorUtil = require("../util/selector"),
+  escapeStringRegexp = require("escapeStringRegexp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -35,7 +36,7 @@ ElContainsText.prototype.command = function (selector, expectedContainedText) {
 ElContainsText.prototype.assert = function (actual, expected) {
   if (expected !== undefined 
     && actual.indexOf(expected) < 0 
-    && !(new RegExp(expected).exec(actual))) {
+    && !(new RegExp(escapeStringRegexp(expected)).exec(actual))) {
     this.pass(actual, expected, this.message);
   } else {
     this.fail(actual, expected, this.message, this.failureDetails);

--- a/lib/assertions/elValueContains.js
+++ b/lib/assertions/elValueContains.js
@@ -1,7 +1,8 @@
 // Assert whether a selector contains a given text
 
 var util = require("util"),
-  selectorUtil = require("../util/selector");
+  selectorUtil = require("../util/selector"),
+  escapeStringRegexp = require("escapeStringRegexp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -35,7 +36,7 @@ ElValueContains.prototype.command = function (selector, expectedContainedText) {
 ElValueContains.prototype.assert = function (actual, expected) {
   if (expected === undefined 
     || actual.indexOf(expected) < 0
-    || !(new RegExp(expected).exec(actual))) {
+    || !(new RegExp(escapeStringRegexp(expected)).exec(actual))) {
     this.fail(actual, expected, this.message, this.failureDetails);
   } else {
     this.pass(actual, expected, this.message);

--- a/lib/assertions/elValueContains.js
+++ b/lib/assertions/elValueContains.js
@@ -2,7 +2,7 @@
 
 var util = require("util"),
   selectorUtil = require("../util/selector"),
-  escapeStringRegexp = require("escapeStringRegexp");
+  escapeRegExp = require("lodash/escapeRegExp");
 
 var BaseElAssertion = require("./base/baseElAssertion");
 
@@ -36,7 +36,7 @@ ElValueContains.prototype.command = function (selector, expectedContainedText) {
 ElValueContains.prototype.assert = function (actual, expected) {
   if (expected === undefined 
     || actual.indexOf(expected) < 0
-    || !(new RegExp(escapeStringRegexp(expected)).exec(actual))) {
+    || !(new RegExp(escapeRegExp(expected)).exec(actual))) {
     this.fail(actual, expected, this.message, this.failureDetails);
   } else {
     this.pass(actual, expected, this.message);

--- a/package.json
+++ b/package.json
@@ -73,9 +73,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cli-color": "0.3.2",
-    "escape-string-regexp": "^1.0.5",
-    "json-stringify-safe": "5.0.0",
+    "cli-color": "0.3.2"
     "jsonfile": "2.0.0",
     "lodash": "^4.6.1",
     "q": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "license": "MIT",
   "dependencies": {
     "cli-color": "0.3.2",
+    "escape-string-regexp": "^1.0.5",
     "json-stringify-safe": "5.0.0",
     "jsonfile": "2.0.0",
     "lodash": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "cli-color": "0.3.2"
+    "cli-color": "0.3.2",
     "jsonfile": "2.0.0",
     "lodash": "^4.6.1",
     "q": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "license": "MIT",
   "dependencies": {
     "cli-color": "0.3.2",
+    "json-stringify-safe": "5.0.0",
     "jsonfile": "2.0.0",
     "lodash": "^4.6.1",
     "q": "1.0.1",


### PR DESCRIPTION
Regex needs to be passed an escaped string else it fail the assertion if a non-regex is passed as a parameter to these assertions.

**Fixes Bug:**

```
Testing if selector <[data-automation-id='phone-cc']> has value <(510) 123-1234> after 16623 milliseconds   - expected "(510) 123-1234" but got: (510) 123-1234
```

@Maciek416 @archlichking @geekdave 
