### PR TITLE
remove comments in injectedjs to support android emulator

### DIFF
--- a/lib/injections/js-injection.js
+++ b/lib/injections/js-injection.js
@@ -8,14 +8,12 @@ module.exports = {
   },
 
   executeSizzlejs: function (sel, injectedJsCommand, sizzleSource) {
-    /* In context of browser, ask if the selector is :visible according to sizzle */
     var result = {
       isVisibleStrict: null,
       isVisible: false,
       selectorVisibleLength: 0,
       selectorLength: 0,
       value: {
-        // for `clickEl`, need to check if it is still needed
         sel: sel,
         value: null
       }
@@ -26,7 +24,6 @@ module.exports = {
     if (window.Sizzle) {
       sizzleRef = window.Sizzle;
     } else if (window.jQuery) {
-      // if we have jquery, we'll use jquery's native sizzle
       sizzleRef = window.jQuery.find;
     } else {
       eval(sizzleSource);
@@ -35,7 +32,6 @@ module.exports = {
     }
 
     if (!sizzleRef) {
-      // there might be error eval() here. we eat the error here and return result as nothing found on page
       return result;
     }
 
@@ -53,10 +49,6 @@ module.exports = {
 
       var $el = sizzleRef(sel);
       if ($el.length > 0 && sizzleRef.matchesSelector($el[0], "area")) {
-        /* Note: this is the only case in which we return a boolean for isVisibleStrict
-         In all other cases, we return null because we effectively "do not know yet".
-         This helps cases like waitForElNotPresent that cannot have "false" returned
-         unless we have successfully checked if it is not visible. */
         result.isVisible = result.isVisibleStrict = true;
         result.selectorVisibleLength = $el.length;
       } else {
@@ -67,19 +59,13 @@ module.exports = {
 
       result.selectorLength = $el.length;
 
-      /* If selector:visible and we have been told to click then signal back that it is okay to click(),
-         unless we see a selector that is ambiguous (i.e number of results
-         is greater than 1). */
       if (result.isVisible) {
-        /* We avoid using data-automation-id so that we do not accidentally blow away existing attributes. */
         var seleniumClickSelectorValue = "magellan_selector_" + Math.round(Math.random() * 999999999).toString(16);
         $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
 
         result.value.value = (new Function("$el", "sizzle", injectedJsCommand))($el, sizzleRef);
       }
     } finally {
-      /* if for whatever reason we fail here, we do not want Selenium returning
-         a null result value back to Magellan. For now, we eat this exception. */
       return result;
     }
 


### PR DESCRIPTION
somehow having comments in injectedjs will cause injection failure in saucelabs android emulator.