### PR TITLE
Loop in js

### DIFF
--- a/lib/assertions/base/baseElAssertion.js
+++ b/lib/assertions/base/baseElAssertion.js
@@ -5,6 +5,7 @@ var _ = require("lodash");
 var jsInjection = require("../../injections/js-injection");
 var selectorUtil = require("../../util/selector");
 var statsd = require("../../util/statsd");
+var settings = require("../../settings");
 
 function BaseAssertion() {
   EventEmitter.call(this);
@@ -23,7 +24,9 @@ BaseAssertion.prototype.execute = function (selector, injectedJsCommand, callbac
   var args = [
     selectorUtil.depageobjectize(selector, this.client.locateStrategy),
     injectedJsCommand,
-    this.getSizzlejsSource()
+    this.getSizzlejsSource(),
+    settings.JS_WAIT_INTERNAL,
+    settings.SEEN_MAX
   ];
 
   // .getEl guarantees Sizzle is always injected before assertion

--- a/lib/assertions/base/baseElAssertion.js
+++ b/lib/assertions/base/baseElAssertion.js
@@ -29,7 +29,7 @@ BaseAssertion.prototype.execute = function (selector, injectedJsCommand, callbac
   // .getEl guarantees Sizzle is always injected before assertion
   this.client.api
     .getEl(selector)
-    .execute(
+    .executeAsync(
       this.executeSizzlejs,
       args,
       function (result) {

--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -137,7 +137,7 @@ MagellanBaseTest.prototype = {
 
       if (!this.isAsyncTimeoutSet) {
         var self = this;
-        client.timeoutsAsyncScript(30000, function () {
+        client.timeoutsAsyncScript(settings.JS_MAX_TIMEOUT, function () {
           self.isAsyncTimeoutSet = true;
           callback();
         });
@@ -173,7 +173,7 @@ MagellanBaseTest.prototype = {
 
       if (!this.isAsyncTimeoutSet) {
         var self = this;
-        client.timeoutsAsyncScript(settings.COMMAND_MAX_TIMEOUT - 5000, function () {
+        client.timeoutsAsyncScript(settings.JS_MAX_TIMEOUT, function () {
           self.isAsyncTimeoutSet = true;
           callback();
         });

--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -173,7 +173,7 @@ MagellanBaseTest.prototype = {
 
       if (!this.isAsyncTimeoutSet) {
         var self = this;
-        client.timeoutsAsyncScript(30000, function () {
+        client.timeoutsAsyncScript(settings.COMMAND_MAX_TIMEOUT - 5000, function () {
           self.isAsyncTimeoutSet = true;
           callback();
         });

--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -101,16 +101,16 @@ MagellanBaseTest.prototype = {
     this.isSupposedToFailInBefore = false;
     this.failures = [];
     this.passed = 0;
+
+    // we only want timeoutsAsyncScript to be set once the whole session to limit 
+    // the number of http requests we sent
+    this.isAsyncTimeoutSet = false;
   },
 
   /*
    * Runs at the beginning of each step
    */
   beforeEach: function (client, callback) {
-    // Note: Sometimes, the session hasn't been established yet but we have control.
-    if (client.sessionId) {
-      settings.sessionId = client.sessionId;
-    }
 
     // Tell reporters that we are starting this test.
     // This logic would ideally go in the "before" block and not "beforeEach"
@@ -131,17 +131,29 @@ MagellanBaseTest.prototype = {
 
       this.notifiedListenersOfStart = true;
     }
-    callback();
+    // Note: Sometimes, the session hasn't been established yet but we have control.
+    if (client.sessionId) {
+      settings.sessionId = client.sessionId;
+
+      if (!this.isAsyncTimeoutSet) {
+        var self = this;
+        client.timeoutsAsyncScript(30000, function () {
+          self.isAsyncTimeoutSet = true;
+          callback();
+        });
+      } else {
+        callback();
+      }
+    } else {
+      callback();
+    }
+
   },
 
   /*
    * Runs at the beginning of each step
    */
   afterEach: function (client, callback) {
-    if (client.sessionId) {
-      settings.sessionId = client.sessionId;
-    }
-
     if (this.results) {
       // in case we failed in `before`
       // keep track of failed tests for reporting purposes
@@ -155,7 +167,22 @@ MagellanBaseTest.prototype = {
         this.passed += this.results.passed;
       }
     }
-    callback();
+    // Note: Sometimes, the session hasn't been established yet but we have control.
+    if (client.sessionId) {
+      settings.sessionId = client.sessionId;
+
+      if (!this.isAsyncTimeoutSet) {
+        var self = this;
+        client.timeoutsAsyncScript(30000, function () {
+          self.isAsyncTimeoutSet = true;
+          callback();
+        });
+      } else {
+        callback();
+      }
+    } else {
+      callback();
+    }
   },
 
   /*

--- a/lib/commands/base/baseElCommand.js
+++ b/lib/commands/base/baseElCommand.js
@@ -29,30 +29,44 @@ BaseElCommand.prototype.execute = function (fn, args, callback) {
   innerArgs.unshift(selector);
   innerArgs.push(this.getSizzlejsSource());
 
-  this.client.api.execute(fn, innerArgs, function (result) {
-
-    if (settings.verbose) {
-      console.log("execute(" + innerArgs + ") intermediate result: ", result);
-    }
-    if (result && result.status === 0 && result.value !== null) {
-      // Note: by checking the result and passing result.value to the callback,
-      // we are claiming that the result sent to the callback will always be truthy
-      // and useful, relieving the callback from needing to check the structural
-      // validity of result or result.value
-
-      callback.call(self, result.value);
-    } else {
-      console.log(clc.yellowBright("\u2622  Received error result from Selenium. Raw Selenium result object:"));
-      var resultDisplay;
-      try {
-        resultDisplay = stringify(result);
-      } catch (e) {
-        resultDisplay = util.inspect(result, false, null);
+  this.client.api
+    .executeAsync(fn, innerArgs, function (result) {
+      if (settings.verbose) {
+        console.log("execute(" + innerArgs + ") intermediate result: ", result);
       }
-      console.log(clc.yellowBright(resultDisplay));
-      self.fail();
-    }
-  });
+      if (result && result.status === 0 && result.value !== null) {
+        // Note: by checking the result and passing result.value to the callback,
+        // we are claiming that the result sent to the callback will always be truthy
+        // and useful, relieving the callback from needing to check the structural
+        // validity of result or result.value
+
+        callback.call(self, result.value);
+      } else if (result && result.status === -1 && result.errorStatus === 13 && result.value !== null) {
+        // errorStatus = 13: javascript error: document unloaded while waiting for result
+        // we want to reload the page
+        callback.call(self, {
+          seens: 0,
+          isVisibleStrict: null,
+          isVisible: false,
+          selectorVisibleLength: 0,
+          selectorLength: 0,
+          value: {
+            sel: null,
+            value: null
+          }
+        });
+      } else {
+        console.log(clc.yellowBright("\u2622  Received error result from Selenium. Raw Selenium result object:"));
+        var resultDisplay;
+        try {
+          resultDisplay = stringify(result);
+        } catch (e) {
+          resultDisplay = util.inspect(result, false, null);
+        }
+        console.log(clc.yellowBright(resultDisplay));
+        self.fail();
+      }
+    });
 };
 
 BaseElCommand.prototype.pass = function (actual, expected) {

--- a/lib/commands/base/baseElCommand.js
+++ b/lib/commands/base/baseElCommand.js
@@ -28,6 +28,8 @@ BaseElCommand.prototype.execute = function (fn, args, callback) {
 
   innerArgs.unshift(selector);
   innerArgs.push(this.getSizzlejsSource());
+  innerArgs.push(settings.JS_WAIT_INTERNAL);
+  innerArgs.push(settings.SEEN_MAX);
 
   this.client.api
     .executeAsync(fn, innerArgs, function (result) {

--- a/lib/commands/clickEl.js
+++ b/lib/commands/clickEl.js
@@ -1,6 +1,5 @@
 var util = require("util");
 var clc = require("cli-color");
-var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -36,7 +35,6 @@ ClickEl.prototype.checkConditions = function () {
   this.execute(
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
-      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       // Keep a running count of how many times we've seen this element visible
       if (result.isVisible && result.selectorLength === 1) {
         self.seenCount++;

--- a/lib/commands/clickEl.js
+++ b/lib/commands/clickEl.js
@@ -1,5 +1,6 @@
 var util = require("util");
 var clc = require("cli-color");
+var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -35,6 +36,7 @@ ClickEl.prototype.checkConditions = function () {
   this.execute(
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
+      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       // Keep a running count of how many times we've seen this element visible
       if (result.isVisible && result.selectorLength === 1) {
         self.seenCount++;
@@ -44,8 +46,8 @@ ClickEl.prototype.checkConditions = function () {
 
       // If we've seen the selector enough times or waited too long,
       //  continue w/ checkElement
-      if (self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
-        if (self.seenCount >= SEEN_MAX) {
+      if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
+        if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX) {
 
           // use selenium click 
           self.do(result.value.value);

--- a/lib/commands/getEl.js
+++ b/lib/commands/getEl.js
@@ -1,5 +1,6 @@
 var util = require("util");
 var clc = require("cli-color");
+var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -25,16 +26,17 @@ GetEl.prototype.checkConditions = function () {
   this.execute(
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
+      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       // Keep a running count of how many times we've seen this element visible
       if (result.isVisible) {
-        self.seenCount++;
+        self.seenCount += 1;
       }
 
       var elapsed = (new Date()).getTime() - self.startTime;
 
       // If we've seen the selector enough times or waited too long, then 
       // it's time to pass or fail and continue the command chain.
-      if (self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
+      if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
 
         // Unlike clickEl, only issue a warning in the getEl() version of this
         if (result.selectorLength > 1) {
@@ -42,7 +44,7 @@ GetEl.prototype.checkConditions = function () {
           console.log("Selector did not disambiguate after " + elapsed + " milliseconds, refine your selector or check DOM for problems.");
         }
 
-        if (self.seenCount >= SEEN_MAX) {
+        if (self.seenCount >= SEEN_MAX || result.seens >= SEEN_MAX) {
           self.pass();
         } else {
           self.fail();

--- a/lib/commands/getEl.js
+++ b/lib/commands/getEl.js
@@ -1,6 +1,5 @@
 var util = require("util");
 var clc = require("cli-color");
-var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -26,7 +25,6 @@ GetEl.prototype.checkConditions = function () {
   this.execute(
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
-      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       // Keep a running count of how many times we've seen this element visible
       if (result.isVisible) {
         self.seenCount += 1;

--- a/lib/commands/getElValue.js
+++ b/lib/commands/getElValue.js
@@ -1,6 +1,5 @@
 var util = require("util");
 var clc = require("cli-color");
-var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -29,7 +28,6 @@ GetElValue.prototype.checkConditions = function () {
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
       // Keep a running count of how many times we've seen this element visible
-      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       if (result.isVisible) {
         self.seenCount++;
       }

--- a/lib/commands/getElValue.js
+++ b/lib/commands/getElValue.js
@@ -1,5 +1,6 @@
 var util = require("util");
 var clc = require("cli-color");
+var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -28,6 +29,7 @@ GetElValue.prototype.checkConditions = function () {
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
       // Keep a running count of how many times we've seen this element visible
+      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       if (result.isVisible) {
         self.seenCount++;
       }
@@ -36,7 +38,7 @@ GetElValue.prototype.checkConditions = function () {
 
       // If we've seen the selector enough times or waited too long, then 
       // it's time to pass or fail and continue the command chain.
-      if (self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
+      if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
 
         // Unlike clickEl, only issue a warning in the getEl() version of this
         if (result.selectorLength > 1) {
@@ -44,7 +46,7 @@ GetElValue.prototype.checkConditions = function () {
           console.log("Selector did not disambiguate after " + elapsed + " milliseconds, refine your selector or check DOM for problems.");
         }
 
-        if (self.seenCount >= SEEN_MAX) {
+        if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX) {
           self.pass(result.value.value, self.selector);
         } else {
           self.fail();

--- a/lib/commands/getEls.js
+++ b/lib/commands/getEls.js
@@ -1,5 +1,6 @@
 var util = require("util");
 var clc = require("cli-color");
+var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -26,15 +27,16 @@ GetEls.prototype.checkConditions = function () {
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
       // Keep a running count of how many times we've seen this element visible
+      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       if (result.isVisible) {
-        self.seenCount++;
+        self.seenCount += 1;
       }
 
       var elapsed = (new Date()).getTime() - self.startTime;
 
       // If we've seen the selector enough times or waited too long, then 
       // it's time to pass or fail and continue the command chain.
-      if (self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
+      if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX || elapsed > MAX_TIMEOUT) {
 
         // Unlike clickEl, only issue a warning in the getEl() version of this
         if (result.selectorLength > 1) {
@@ -42,7 +44,7 @@ GetEls.prototype.checkConditions = function () {
           console.log("Selector did not disambiguate after " + elapsed + " milliseconds, refine your selector or check DOM for problems.");
         }
 
-        if (self.seenCount >= SEEN_MAX) {
+        if (result.seens >= SEEN_MAX || self.seenCount >= SEEN_MAX) {
           var ret = [];
           for (var i = 1; i <= result.value.value; i++) {
             ret.push({

--- a/lib/commands/getEls.js
+++ b/lib/commands/getEls.js
@@ -1,6 +1,5 @@
 var util = require("util");
 var clc = require("cli-color");
-var moment = require("moment");
 
 var selectorUtil = require("../util/selector");
 var BaseElCommand = require("./base/baseElCommand");
@@ -27,7 +26,6 @@ GetEls.prototype.checkConditions = function () {
     this.executeSizzlejs, [this.selector, this.injectedJsCommand()],
     function (result) {
       // Keep a running count of how many times we've seen this element visible
-      console.log(moment().format("HH:mm:ss.SSS"), this.cmd, "[", self.seenCount, "]");
       if (result.isVisible) {
         self.seenCount += 1;
       }

--- a/lib/injections/js-injection.js
+++ b/lib/injections/js-injection.js
@@ -57,40 +57,39 @@ module.exports = {
       };
 
 
-    result.count = function () {
+    var count = function () {
       try {
-        var $el = sizzleRef(this.value.sel);
-        this.el = $el
+        var $el = sizzleRef(result.value.sel);
         if ($el.length > 0 && sizzleRef.matchesSelector($el[0], "area")) {
-          this.isVisible = this.isVisibleStrict = true;
-          this.selectorVisibleLength = $el.length;
+          result.isVisible = result.isVisibleStrict = true;
+          result.selectorVisibleLength = $el.length;
         } else {
-          var length = sizzleRef(this.value.sel + ":visible").length;
-          this.isVisibleStrict = this.isVisible = length > 0;
-          this.selectorVisibleLength = length;
+          var length = sizzleRef(result.value.sel + ":visible").length;
+          result.isVisibleStrict = result.isVisible = length > 0;
+          result.selectorVisibleLength = length;
         }
 
-        this.selectorLength = $el.length;
+        result.selectorLength = $el.length;
 
-        if (this.isVisible) {
-          this.seens += 1;
-          if (this.seens >= seenMax) {
+        if (result.isVisible) {
+          result.seens += 1;
+          if (result.seens >= seenMax) {
             var seleniumClickSelectorValue = "magellan_selector_" + Math.round(Math.random() * 999999999).toString(16);
             $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
 
-            this.value.value = (new Function("$el", "sizzle", pInjectedJsCommand))($el, sizzleRef);
-            done(this);
+            result.value.value = (new Function("$el", "sizzle", pInjectedJsCommand))($el, sizzleRef);
+            done(result);
           } else {
-            setTimeout(this.count, waitInterval);
+            setTimeout(count, waitInterval);
           }
         } else {
-          done(this);
+          done(result);
         }
       } catch (e) {
-        done(this);
+        done(result);
       }
-    }.bind(result);
+    };
 
-    result.count();
+    count();
   }
 };

--- a/lib/injections/js-injection.js
+++ b/lib/injections/js-injection.js
@@ -11,9 +11,13 @@ module.exports = {
   /**
    *  android emulator doesn't allow js injection with comments. so add comments
    *  here if comments are needed for `executeSizzlejs` function
+   *  
+   *  element visibility counter has been moved into injected js to limit the number 
+   *  of http requests we have to send to selenium server. this is extremely fast 
+   *  when tests are running against a cloud service provider like saucelabs
    *
    */
-  executeSizzlejs: function (pSel, pInjectedJsCommand, pSizzleSource) {
+  executeSizzlejs: function (pSel, pInjectedJsCommand, pSizzleSource, done) {
     var result = {
       seens: 0,
       isVisibleStrict: null,
@@ -74,18 +78,18 @@ module.exports = {
             $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
 
             this.value.value = (new Function("$el", "sizzle", pInjectedJsCommand))($el, sizzleRef);
-            return;
+            done(this);
+          }else{
+            setTimeout(this.count, 50);
           }
+        }else{
+          done(this);
         }
-      } finally {
-        return;
+      } catch(e) {
+        done(this);
       }
     }.bind(result);
 
-    for (var i = 0; i < 4; i++) {
-      result.count();
-    }
-
-    return result;
+    result.count();
   }
 };

--- a/lib/injections/js-injection.js
+++ b/lib/injections/js-injection.js
@@ -13,14 +13,15 @@ module.exports = {
    *  here if comments are needed for `executeSizzlejs` function
    *
    */
-  executeSizzlejs: function (sel, injectedJsCommand, sizzleSource) {
+  executeSizzlejs: function (pSel, pInjectedJsCommand, pSizzleSource) {
     var result = {
+      seens: 0,
       isVisibleStrict: null,
       isVisible: false,
       selectorVisibleLength: 0,
       selectorLength: 0,
       value: {
-        sel: sel,
+        sel: pSel,
         value: null
       }
     };
@@ -32,7 +33,7 @@ module.exports = {
     } else if (window.jQuery) {
       sizzleRef = window.jQuery.find;
     } else {
-      eval(sizzleSource);
+      eval(pSizzleSource);
       sizzleRef = Sizzle;
       sizzleRef.noConflict();
     }
@@ -51,29 +52,40 @@ module.exports = {
       };
 
 
-    try {
+    result.count = function () {
+      try {
+        var $el = sizzleRef(this.value.sel);
+        this.el = $el
+        if ($el.length > 0 && sizzleRef.matchesSelector($el[0], "area")) {
+          this.isVisible = this.isVisibleStrict = true;
+          this.selectorVisibleLength = $el.length;
+        } else {
+          var length = sizzleRef(this.value.sel + ":visible").length;
+          this.isVisibleStrict = this.isVisible = length > 0;
+          this.selectorVisibleLength = length;
+        }
 
-      var $el = sizzleRef(sel);
-      if ($el.length > 0 && sizzleRef.matchesSelector($el[0], "area")) {
-        result.isVisible = result.isVisibleStrict = true;
-        result.selectorVisibleLength = $el.length;
-      } else {
-        var length = sizzleRef(sel + ":visible").length;
-        result.isVisibleStrict = result.isVisible = length > 0;
-        result.selectorVisibleLength = length;
+        this.selectorLength = $el.length;
+
+        if (this.isVisible) {
+          this.seens += 1;
+          if (this.seens >= 3) {
+            var seleniumClickSelectorValue = "magellan_selector_" + Math.round(Math.random() * 999999999).toString(16);
+            $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
+
+            this.value.value = (new Function("$el", "sizzle", pInjectedJsCommand))($el, sizzleRef);
+            return;
+          }
+        }
+      } finally {
+        return;
       }
+    }.bind(result);
 
-      result.selectorLength = $el.length;
-
-      if (result.isVisible) {
-        var seleniumClickSelectorValue = "magellan_selector_" + Math.round(Math.random() * 999999999).toString(16);
-        $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
-
-        result.value.value = (new Function("$el", "sizzle", injectedJsCommand))($el, sizzleRef);
-      }
-    } finally {
-      return result;
+    for (var i = 0; i < 4; i++) {
+      result.count();
     }
 
+    return result;
   }
 };

--- a/lib/injections/js-injection.js
+++ b/lib/injections/js-injection.js
@@ -17,7 +17,8 @@ module.exports = {
    *  when tests are running against a cloud service provider like saucelabs
    *
    */
-  executeSizzlejs: function (pSel, pInjectedJsCommand, pSizzleSource, done) {
+  executeSizzlejs: function (pSel, pInjectedJsCommand, pSizzleSource,
+    waitInterval, seenMax, done) {
     var result = {
       seens: 0,
       isVisibleStrict: null,
@@ -73,19 +74,19 @@ module.exports = {
 
         if (this.isVisible) {
           this.seens += 1;
-          if (this.seens >= 3) {
+          if (this.seens >= seenMax) {
             var seleniumClickSelectorValue = "magellan_selector_" + Math.round(Math.random() * 999999999).toString(16);
             $el[0].setAttribute("data-magellan-temp-automation-id", seleniumClickSelectorValue);
 
             this.value.value = (new Function("$el", "sizzle", pInjectedJsCommand))($el, sizzleRef);
             done(this);
-          }else{
-            setTimeout(this.count, 50);
+          } else {
+            setTimeout(this.count, waitInterval);
           }
-        }else{
+        } else {
           done(this);
         }
-      } catch(e) {
+      } catch (e) {
         done(this);
       }
     }.bind(result);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -77,7 +77,8 @@ if (argv.screenshot_path) {
 
 var DEFAULT_MAX_TIMEOUT = 60000;
 var timeoutValue = config.nightwatchConfig.test_settings.default.max_timeout || DEFAULT_MAX_TIMEOUT;
-
+var JS_MAX_TIMEOUT_OFFSET = 5000;
+var jsTimeoutValue = timeoutValue - JS_MAX_TIMEOUT_OFFSET;
 
 module.exports = {
   screenshotPath: screenshotPath,
@@ -88,6 +89,7 @@ module.exports = {
   isWorker: !!argv.worker,
 
   COMMAND_MAX_TIMEOUT: timeoutValue,
+  JS_MAX_TIMEOUT: jsTimeoutValue,
   WAIT_INTERVAL: 100,
   JS_WAIT_INTERNAL: 50,
   SEEN_MAX: 3,

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -89,8 +89,9 @@ module.exports = {
 
   COMMAND_MAX_TIMEOUT: timeoutValue,
   WAIT_INTERVAL: 100,
+  JS_WAIT_INTERNAL: 50,
   SEEN_MAX: 3,
-  
+
   verbose: argv.verbose,
 
   sessionId: undefined

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "json-stringify-safe": "5.0.0",
     "jsonfile": "2.0.0",
     "lodash": "^4.6.1",
+    "moment": "^2.13.0",
     "q": "1.0.1",
     "request": "2.40.0",
     "sanitize-filename": "1.3.0",

--- a/tests/google.js
+++ b/tests/google.js
@@ -24,8 +24,6 @@ module.exports = new Test({
   "type search term": function (client) {
     client
       .setElValue("[name='q']", "hahaha")
-      // .clearValue("[name='q']")
-      // .setMaskedElValue("[name='q']", "hahaha")
       .clickEl(".lsb")
       .assert.elContainsText("#resultStats", "About");
   },


### PR DESCRIPTION
The most expensive operation(s) of a selenium command is the http call made to selenium server. This PR is to limit the number of necessary http requests one selenium command is going to send.

To do so, the logic of `operate-until-the-element-is-visible-for-three-times` has been moved into the injected javascript. The original `operate-until-the-element-is-visible-for-three-times` logic is still in the extra command in case that page is redirecting when the js injection is happening.

Key changes
```
1. change client.execute to client.executeAsync
2. add client.timeoutsAsyncScript
3. move element visibility test logic into injected javascript 
```

@Maciek416 @geekdave 