### PR TITLE
add options and disable timeout so that the browser does not timeout prematurely an the test is executed

### DIFF
--- a/lib/base-test-class.js
+++ b/lib/base-test-class.js
@@ -97,12 +97,13 @@ var MagellanBaseTest = function (steps) {
 };
 
 MagellanBaseTest.prototype = {
-  before: function (client) {
+  before: function (client, options) {
+    this.options = options || {};
     this.isSupposedToFailInBefore = false;
     this.failures = [];
     this.passed = 0;
 
-    // we only want timeoutsAsyncScript to be set once the whole session to limit 
+    // we only want timeoutsAsyncScript to be set once the whole session to limit
     // the number of http requests we sent
     this.isAsyncTimeoutSet = false;
   },
@@ -136,7 +137,7 @@ MagellanBaseTest.prototype = {
       settings.sessionId = client.sessionId;
     }
 
-    if (!this.isAsyncTimeoutSet) {
+    if (!this.options.disableTimeout && !this.isAsyncTimeoutSet) {
       var self = this;
       client.timeoutsAsyncScript(settings.JS_MAX_TIMEOUT, function () {
         self.isAsyncTimeoutSet = true;


### PR DESCRIPTION
add options 
disable timeout so that the browser does not timeout prematurely and the test is executed

this will be consumed by: https://gecgithub01.walmart.com/WTG/w2g-web/pull/1320
and will allow to run multiple workers without the browser being stuck because of the timeout