### PR TITLE
Emit metadata instead of sessionid to magellan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-nightwatch-extra",
-  "version": "4.1.7",
+  "version": "4.2.0",
   "description": "extra useful nightwatch command and assertion",
   "main": "index.js",
   "scripts": {

--- a/src/base-test-class.js
+++ b/src/base-test-class.js
@@ -64,7 +64,10 @@ BaseTest.prototype = {
       settings.sessionId = client.sessionId;
 
       if (this.isWorker) {
-        this.worker.emitSession(client.sessionId);
+        this.worker.emitMetadata({
+          sessionId: settings.sessionId,
+          capabilities: client.capabilities
+        });
       }
     }
   },
@@ -94,7 +97,10 @@ BaseTest.prototype = {
       settings.sessionId = client.sessionId;
 
       if (this.isWorker) {
-        this.worker.emitSession(client.sessionId);
+        this.worker.emitMetadata({
+          sessionId: settings.sessionId,
+          capabilities: client.capabilities
+        });
       }
     }
 

--- a/src/worker/magellan.js
+++ b/src/worker/magellan.js
@@ -3,21 +3,23 @@ export default class MagellanWorker {
     this.nightwatch = nightwatch;
   }
 
-  emitSession(sessionId) {
+  emitMetadata(metadata) {
     /* istanbul ignore if */
-    if (process.send) {
-      let url = "https://saucelabs.com/tests/";
-
-      if (this.nightwatch.globals.resultUrlPrefix) {
-        url = this.nightwatch.globals.resultUrlPrefix;
+    // nightwatch will add response from /session to capabilities
+    // we need that info to compose the result sometimes
+    /*
+      metadata: {
+        sessionId: sessionId
+        capabilities: capabilities
       }
+     */
+    if (process.send) {
+      // notice: each executor will generate report url by itself
+      //         only meta data is emitted here
 
       process.send({
         type: "test-meta-data",
-        metadata: {
-          resultURL: url + sessionId,
-          sessionId
-        }
+        metadata
       });
     }
   }


### PR DESCRIPTION
Emit metadata to expose more information to executors.