### PR TITLE
Fix bail reason

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - ./node_modules/.bin/magellan --external_build_id=$TRAVIS_BUILD_ID --sauce_create_tunnels --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --max_workers=${MAGELLAN_MAX_WORKERS} --sauce_browsers=${TIER_1_2_BROWSERS} --nightwatch_config tests/conf/nightwatch.json --sync_browsers safari:10,iphone,ipad --config tests/magellan.json
 
 env:
-  - TIER_1_2_BROWSERS=microsoftedge_14_Windows_10_Desktop,safari_10_OS_X_10_11_Desktop,IE_11_Windows_10_Desktop,safari_9_OS_X_10_11_Desktop,IE_11_Windows_10_Desktop,IE_10_Windows_2012_Desktop,firefox_50_Windows_2012_R2_Desktop
+  - TIER_1_2_BROWSERS=microsoftedge_14_Windows_10_Desktop,safari_10_OS_X_10_11_Desktop,safari_9_OS_X_10_11_Desktop,IE_11_Windows_10_Desktop,IE_10_Windows_2012_Desktop,firefox_54_Windows_2012_R2_Desktop
 
 node_js:
   - v7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-nightwatch-extra",
-  "version": "4.1.7",
+  "version": "4.2.0",
   "description": "extra useful nightwatch command and assertion",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testarmada-nightwatch-extra",
-  "version": "4.2.2",
+  "version": "4.2.4",
   "description": "extra useful nightwatch command and assertion",
   "main": "index.js",
   "scripts": {

--- a/src/base-test-class.js
+++ b/src/base-test-class.js
@@ -64,7 +64,10 @@ BaseTest.prototype = {
       settings.sessionId = client.sessionId;
 
       if (this.isWorker) {
-        this.worker.emitSession(client.sessionId);
+        this.worker.emitMetadata({
+          sessionId: settings.sessionId,
+          capabilities: client.capabilities
+        });
       }
     }
   },
@@ -94,7 +97,10 @@ BaseTest.prototype = {
       settings.sessionId = client.sessionId;
 
       if (this.isWorker) {
-        this.worker.emitSession(client.sessionId);
+        this.worker.emitMetadata({
+          sessionId: settings.sessionId,
+          capabilities: client.capabilities
+        });
       }
     }
 

--- a/src/worker/magellan.js
+++ b/src/worker/magellan.js
@@ -27,7 +27,8 @@ export default class MagellanWorker {
   handleMessage(message) {
     /* istanbul ignore if */
     if (message && message.signal === "bail") {
-      this.nightwatch.assert.equal(false, true, message.customMessage || "Test killed.");
+      // instead of counting on assertion, we throws error out and fail the test directly
+      throw new Error(message.customMessage || "Test killed.");
     }
   }
 }

--- a/src/worker/magellan.js
+++ b/src/worker/magellan.js
@@ -3,21 +3,23 @@ export default class MagellanWorker {
     this.nightwatch = nightwatch;
   }
 
-  emitSession(sessionId) {
+  emitMetadata(metadata) {
     /* istanbul ignore if */
-    if (process.send) {
-      let url = "https://saucelabs.com/tests/";
-
-      if (this.nightwatch.globals.resultUrlPrefix) {
-        url = this.nightwatch.globals.resultUrlPrefix;
+    // nightwatch will add response from /session to capabilities
+    // we need that info to compose the result sometimes
+    /*
+      metadata: {
+        sessionId: sessionId
+        capabilities: capabilities
       }
+     */
+    if (process.send) {
+      // notice: each executor will generate report url by itself
+      //         only meta data is emitted here
 
       process.send({
         type: "test-meta-data",
-        metadata: {
-          resultURL: url + sessionId,
-          sessionId
-        }
+        metadata
       });
     }
   }

--- a/tests/conf/nightwatch.json
+++ b/tests/conf/nightwatch.json
@@ -13,7 +13,7 @@
   ],
   "selenium": {
     "start_process": true,
-    "server_path": "./node_modules/selenium-server/lib/runner/selenium-server-standalone-3.0.1.jar",
+    "server_path": "./node_modules/selenium-server/lib/runner/selenium-server-standalone-3.3.1.jar",
     "log_path": "reports",
     "host": "127.0.0.1",
     "port": 4444,

--- a/tests/google.js
+++ b/tests/google.js
@@ -26,8 +26,9 @@ module.exports = new Test({
       .setElValue("[name='q']", "xixixix")
       .clearElValue("[name='q']")
       .setElValue("[name='q']", "hahaha")
-      .clickEl("#sfdiv button")
-      .takeElScreenshot("#resultStats", "About")
+      .clickEl("#hplogo")
+      .clickEl("[value='Google Search']:visible")
+      // .takeElScreenshot("#resultStats", "About")
       .assert.elContainsText("#resultStats", "About");
   },
 


### PR DESCRIPTION
When test bails, nightwatch instance will be destroyed before the child process is able to handle the message back from magellan process. This behavior causes a bug where 

```
✖ Error: Killed by magellan after 5000ms (long running test)
    at process.nextTick (internal/child_process.js:758:12)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
FAILED:  1 errors (3.429s)
```

should be in the output instead of
```
_immediateCallback: [Function: processImmediate] }
✖ TypeError: Cannot read property 'assert' of undefined
    at process.nextTick (internal/child_process.js:758:12)
    at _combinedTickCallback (internal/process/next_tick.js:73:7)
    at process._tickDomainCallback (internal/process/next_tick.js:128:9)
FAILED:  1 errors (3.44s)
``` 

test fails still but it fails with a totally different reason (calling assert on an undefined object instead of the correct bail result).