### PR TITLE
Added error dictionary

### DIFF
--- a/src/assertions/mobile/mobileElAttrContains.js
+++ b/src/assertions/mobile/mobileElAttrContains.js
@@ -14,7 +14,9 @@ MobileElAttrContains.prototype.do = function (value) {
 
   this.client.api
     .elementIdAttribute(value.ELEMENT, this.attr, (result) => {
-      if (result.status === 0) {
+      if(result.value === null){
+        self.fail("[attribute not found]", self.expected, self.message + "[ATTRIBUTE_NOT_FOUND]");
+      } else if (result.status === 0) {
         self.assert(result.value, self.expected);
       } else {
         self.fail("selenium return.status=0",

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -12,6 +12,8 @@ import jsInjection from "./injections/js-injection";
 import stats from "./util/stats";
 import logger from "./util/logger";
 
+import errorDictionary from "./errorDictionary";
+
 // Wait until we've seen a selector as :visible SEEN_MAX times, with a
 // wait for WAIT_INTERVAL milliseconds between each visibility test.
 const MAX_TIMEOUT = settings.COMMAND_MAX_TIMEOUT;
@@ -46,6 +48,8 @@ const Base = function (nightwatch = null, customizedSettings = null) {
   if (customizedSettings) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
+
+  errorDictionary.init(this.client.options.errorDictionary);
 };
 
 util.inherits(Base, EventEmitter);
@@ -218,7 +222,7 @@ Base.prototype.fail = function (actual, expected, message, detail) {
   const fmtmessage = (this.isSync ? "[sync mode] " : "") + this.message;
 
   this.client.assertion(false, actual, expected,
-    util.format(fmtmessage, this.time.totalTime), true);
+    errorDictionary.format(util.format(fmtmessage, this.time.totalTime)), true);
   this.emit("complete");
 };
 

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -49,7 +49,7 @@ const Base = function (nightwatch = null, customizedSettings = null) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
 
-  errorDictionary.init(this.client.options.errorDictionary);
+  errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || this.client.options.errorDictionary);
 };
 
 util.inherits(Base, EventEmitter);

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -137,9 +137,15 @@ Base.prototype.checkConditions = function () {
           self.assert(result.value.value, self.expected);
         } else {
           if(result.selectorLength === 1){
-            self.fail("[not visible]", this.expected, this.message + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
+            self.fail("[not visible]", self.expected, self.message + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
           }else{
-            self.fail("[not found]", this.expected, this.message + "[" + settings.SELECTOR_NOT_FOUND + "]");
+            self.client.api.title(function(title){
+              if(title.value === 'Bad Gateway' || title.value === 'Can\'t reach this page'){
+                self.fail("[bad gateway]", self.expected, self.message + "[" + settings.BAD_GATEWAY + "]");
+              }else{
+                self.fail("[not found]", self.expected, self.message + "[" + settings.SELECTOR_NOT_FOUND + "]");
+              }
+            });
           }
         }
       } else {

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -136,7 +136,11 @@ Base.prototype.checkConditions = function () {
           self.time.seleniumCallTime = 0;
           self.assert(result.value.value, self.expected);
         } else {
-          self.fail(null, null, self.notVisibleFailureMessage);
+          if(result.selectorLength === 1){
+            self.fail("[not visible]", this.expected, this.message + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
+          }else{
+            self.fail("[not found]", this.expected, this.message + "[" + settings.SELECTOR_NOT_FOUND + "]");
+          }
         }
       } else {
         setTimeout(self.checkConditions, WAIT_INTERVAL);
@@ -195,7 +199,7 @@ Base.prototype.execute = function (fn, args, callback) {
         resultDisplay = util.inspect(result, false, null);
       }
       logger.warn(clc.yellowBright(resultDisplay));
-      self.fail();
+      self.fail("[selenium error]", this.expected, resultDisplay + "[" + settings.SELENIUM_ERROR + "]");
     }
   });
 };
@@ -219,7 +223,7 @@ Base.prototype.pass = function (actual, expected, message) {
 /*eslint max-params:["error", 4] */
 Base.prototype.fail = function (actual, expected, message, detail) {
   this.time.totalTime = (new Date()).getTime() - this.startTime;
-  const fmtmessage = (this.isSync ? "[sync mode] " : "") + this.message;
+  const fmtmessage = (this.isSync ? "[sync mode] " : "") + (message || this.message);
 
   this.client.assertion(false, actual, expected,
     errorDictionary.format(util.format(fmtmessage, this.time.totalTime)), true);

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -49,8 +49,6 @@ const Base = function (nightwatch = null, customizedSettings = null) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
 
-  errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || this.client.options.errorDictionary);
-
   if(this.client && this.client.queue && typeof(this.client.queue.instance === 'function')){
     let instance = this.client.queue.instance();
     if(instance && instance.currentNode){
@@ -144,13 +142,13 @@ Base.prototype.checkConditions = function () {
           self.assert(result.value.value, self.expected);
         } else {
           if(result.selectorLength === 1){
-            self.fail("[not visible]", self.expected, self.message + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
+            self.fail("[not visible]", self.expected, self.message + "[SELECTOR_NOT_VISIBLE]");
           }else{
             self.client.api.title(function(title){
               if(title.value === 'Bad Gateway' || title.value === 'Can\'t reach this page'){
-                self.fail("[bad gateway]", self.expected, self.message + "[" + settings.BAD_GATEWAY + "]");
+                self.fail("[bad gateway]", self.expected, self.message + "[BAD_GATEWAY]");
               }else{
-                self.fail("[not found]", self.expected, self.message + "[" + settings.SELECTOR_NOT_FOUND + "]");
+                self.fail("[not found]", self.expected, self.message + "[SELECTOR_NOT_FOUND ]");
               }
             });
           }
@@ -212,7 +210,7 @@ Base.prototype.execute = function (fn, args, callback) {
         resultDisplay = util.inspect(result, false, null);
       }
       logger.warn(clc.yellowBright(resultDisplay));
-      self.fail("[selenium error]", this.expected, resultDisplay + "[" + settings.SELENIUM_ERROR + "]");
+      self.fail("[selenium error]", this.expected, resultDisplay + "[SELENIUM_ERROR]");
     }
   });
 };

--- a/src/base-assertion.js
+++ b/src/base-assertion.js
@@ -50,6 +50,13 @@ const Base = function (nightwatch = null, customizedSettings = null) {
   }
 
   errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || this.client.options.errorDictionary);
+
+  if(this.client && this.client.queue && typeof(this.client.queue.instance === 'function')){
+    let instance = this.client.queue.instance();
+    if(instance && instance.currentNode){
+      this.stackTrace = instance.currentNode.stackTrace;
+    }
+  }
 };
 
 util.inherits(Base, EventEmitter);
@@ -229,10 +236,8 @@ Base.prototype.pass = function (actual, expected, message) {
 /*eslint max-params:["error", 4] */
 Base.prototype.fail = function (actual, expected, message, detail) {
   this.time.totalTime = (new Date()).getTime() - this.startTime;
-  const fmtmessage = (this.isSync ? "[sync mode] " : "") + (message || this.message);
-
-  this.client.assertion(false, actual, expected,
-    errorDictionary.format(util.format(fmtmessage, this.time.totalTime)), true);
+  const fmtmessage = errorDictionary.format(util.format((this.isSync ? "[sync mode] " : "") + (message || this.message), this.time.totalTime));
+  this.client.assertion(false, actual, expected, fmtmessage, true, this.stackTrace);
   this.emit("complete");
 };
 

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -47,7 +47,7 @@ const Base = function (nightwatch = null, customizedSettings = null) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
 
-  errorDictionary.init(this.client.options.errorDictionary);
+  errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || this.client.options.errorDictionary);
 };
 
 util.inherits(Base, EventEmitter);

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -137,7 +137,13 @@ Base.prototype.checkConditions = function () {
           if(result.selectorLength === 1){
             self.fail("[not visible]", "[visible]", this.failureMessage + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
           }else{
-            self.fail("[not found]", "[found]", this.failureMessage + "[" + settings.SELECTOR_NOT_FOUND + "]");
+            self.client.api.title(function(title){
+              if(title.value === 'Bad Gateway' || title.value === 'Can\'t reach this page'){
+                self.fail("[bad gateway]", "[found]", self.failureMessage + "[" + settings.BAD_GATEWAY + "]");
+              }else{
+                self.fail("[not found]", "[found]", self.failureMessage + "[" + settings.SELECTOR_NOT_FOUND + "]");
+              }
+            });
           }
         }
       } else {

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -47,8 +47,6 @@ const Base = function (nightwatch = null, customizedSettings = null) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
 
-  errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || this.client.options.errorDictionary);
-
   if(this.client && this.client.queue && typeof(this.client.queue.instance === 'function')){
     let instance = this.client.queue.instance();
     if(instance && instance.currentNode){
@@ -142,13 +140,13 @@ Base.prototype.checkConditions = function () {
           self.do(result.value.value);
         } else {
           if(result.selectorLength === 1){
-            self.fail("[not visible]", "[visible]", this.failureMessage + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
+            self.fail("[not visible]", "[visible]", this.failureMessage + "[SELECTOR_NOT_VISIBLE]");
           }else{
             self.client.api.title(function(title){
               if(title.value === 'Bad Gateway' || title.value === 'Can\'t reach this page'){
-                self.fail("[bad gateway]", "[found]", self.failureMessage + "[" + settings.BAD_GATEWAY + "]");
+                self.fail("[bad gateway]", "[found]", self.failureMessage + "[BAD_GATEWAY]");
               }else{
-                self.fail("[not found]", "[found]", self.failureMessage + "[" + settings.SELECTOR_NOT_FOUND + "]");
+                self.fail("[not found]", "[found]", self.failureMessage + "[SELECTOR_NOT_FOUND]");
               }
             });
           }
@@ -210,7 +208,7 @@ Base.prototype.execute = function (fn, args, callback) {
         resultDisplay = util.inspect(result, false, null);
       }
       logger.warn(clc.yellowBright(resultDisplay));
-      self.fail("[selenium error]", "[visible]", resultDisplay + "[" + settings.SELENIUM_ERROR + "]");
+      self.fail("[selenium error]", "[visible]", resultDisplay + "[SELENIUM_ERROR]");
     }
   });
 };

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -134,7 +134,11 @@ Base.prototype.checkConditions = function () {
           self.time.seleniumCallTime = 0;
           self.do(result.value.value);
         } else {
-          self.fail();
+          if(result.selectorLength === 1){
+            self.fail("[not visible]", "[visible]", this.failureMessage + "[" + settings.SELECTOR_NOT_VISIBLE + "]");
+          }else{
+            self.fail("[not found]", "[found]", this.failureMessage + "[" + settings.SELECTOR_NOT_FOUND + "]");
+          }
         }
       } else {
         setTimeout(self.checkConditions, WAIT_INTERVAL);
@@ -193,7 +197,7 @@ Base.prototype.execute = function (fn, args, callback) {
         resultDisplay = util.inspect(result, false, null);
       }
       logger.warn(clc.yellowBright(resultDisplay));
-      self.fail();
+      self.fail("[selenium error]", "[visible]", resultDisplay + "[" + settings.SELENIUM_ERROR + "]");
     }
   });
 };
@@ -220,10 +224,10 @@ Base.prototype.pass = function (actual, expected) {
   this.emit("complete");
 };
 
-Base.prototype.fail = function (actual, expected) {
+Base.prototype.fail = function (actual, expected, failureMessage) {
   const pactual = actual || "not visible";
   const pexpected = expected || "visible";
-  const message = (this.isSync ? "[sync mode] " : "") + this.failureMessage;
+  const message = (this.isSync ? "[sync mode] " : "") + (failureMessage || this.failureMessage);
 
   this.time.totalTime = (new Date()).getTime() - this.startTime;
   this.client.assertion(false, pactual, pexpected, errorDictionary.format(util.format(message, this.time.totalTime)), true);

--- a/src/base-command.js
+++ b/src/base-command.js
@@ -10,6 +10,8 @@ import jsInjection from "./injections/js-injection";
 import stats from "./util/stats";
 import logger from "./util/logger";
 
+import errorDictionary from "./errorDictionary";
+
 // Wait until we've seen a selector as :visible SEEN_MAX times, with a
 // wait for WAIT_INTERVAL milliseconds between each visibility test.
 const MAX_TIMEOUT = settings.COMMAND_MAX_TIMEOUT;
@@ -44,6 +46,8 @@ const Base = function (nightwatch = null, customizedSettings = null) {
   if (customizedSettings) {
     this.syncModeBrowserList = customizedSettings.syncModeBrowserList;
   }
+
+  errorDictionary.init(this.client.options.errorDictionary);
 };
 
 util.inherits(Base, EventEmitter);
@@ -222,7 +226,7 @@ Base.prototype.fail = function (actual, expected) {
   const message = (this.isSync ? "[sync mode] " : "") + this.failureMessage;
 
   this.time.totalTime = (new Date()).getTime() - this.startTime;
-  this.client.assertion(false, pactual, pexpected, util.format(message, this.time.totalTime), true);
+  this.client.assertion(false, pactual, pexpected, errorDictionary.format(util.format(message, this.time.totalTime)), true);
 
   if (this.cb) {
     this.cb.apply(this.client.api, []);

--- a/src/commands/mobile/clickMobileEl.js
+++ b/src/commands/mobile/clickMobileEl.js
@@ -16,7 +16,15 @@ ClickMobileEl.prototype.do = function (value) {
       if (result.status === 0) {
         self.pass(result.value);
       } else {
-        self.fail();
+        let errorMsg = null;
+        if(result.error){
+          if(result.error.indexOf("not visible") > -1){
+            errorMsg = self.failureMessage + "[SELECTOR_NOT_VISIBLE]";
+          }else{
+            errorMsg = self.failureMessage + "[" + result.error + "]";
+          }
+        }
+        self.fail(null, null, errorMsg);
       }
     });
 };

--- a/src/commands/mobile/getMobileElValue.js
+++ b/src/commands/mobile/getMobileElValue.js
@@ -16,7 +16,15 @@ GetMobileElValue.prototype.do = function (value) {
       if (result.status === 0) {
         self.pass(result.value);
       } else {
-        self.fail();
+        let errorMsg = null;
+        if(result.error){
+          if(result.error.indexOf("not visible") > -1){
+            errorMsg = self.failureMessage + "[SELECTOR_NOT_VISIBLE]";
+          }else{
+            errorMsg = self.failureMessage + "[" + result.error + "]";
+          }
+        }
+        self.fail(null, null, errorMsg);
       }
     });
 };

--- a/src/commands/mobile/setMobileElValue.js
+++ b/src/commands/mobile/setMobileElValue.js
@@ -16,7 +16,7 @@ SetMobileElValue.prototype.do = function (value) {
       if (result.status === 0) {
         self.pass(result.value);
       } else {
-        self.fail();
+        self.fail(null, null, result.error);
       }
     });
 };

--- a/src/errorDictionary.js
+++ b/src/errorDictionary.js
@@ -9,18 +9,20 @@ module.exports = {
 
       var client = config.protocol === 'https:' ? https : http;
 
-      client.get(config, function(response) {
-          // Continuously update stream with data
-          var body = '';
-          response.on('data', function(d) {
-              body += d;
-          });
-          response.on('end', function() {
-              dictionary = JSON.parse(body);
-          });
-          response.on('error', function(e){
-            console.log(e);
-          });
+      client.get(config, function (response) {
+        // Continuously update stream with data
+        var body = '';
+        response.on('data', function (d) {
+          body += d;
+        });
+        response.on('end', function () {
+          dictionary = JSON.parse(body);
+        });
+        response.on('error', function (e) {
+          console.log("Error loading error dictionary. " + JSON.stringify(e));
+        });
+      }).on('error', function(e){
+        console.log("Error loading error dictionary. " + JSON.stringify(e));
       });
     }
   },
@@ -28,8 +30,9 @@ module.exports = {
     let ret = error;
     if(dictionary){
       Object.entries(dictionary).forEach(([key, value]) => {
-        if(error.match(new RegExp(key))){
-          ret += ". " + value;
+        let regex = new RegExp(key);
+        if(error.match(regex)){
+          ret = error.replace(regex, value);
         }
       });
     }

--- a/src/errorDictionary.js
+++ b/src/errorDictionary.js
@@ -1,3 +1,4 @@
+import fs from "fs";
 
 let dictionary;
 
@@ -5,42 +6,57 @@ module.exports = {
   init: function (config) {
     if(!dictionary && config){
 
-      if(typeof(config) === 'string' && config.startsWith("{")){
-        config = JSON.parse(config);
+      // check if file
+      if(typeof(config) === 'string' && fs.existsSync(config)){
+        try{
+          dictionary = JSON.parse(fs.readFileSync(config, 'utf8'));
+        }catch(e){
+          console.warn("Error loading error dictionary from file " + config + ". " + JSON.stringify(e));
+        }
+      }else{
+
+        if(typeof(config) === 'string' && config.startsWith("{")){
+          config = JSON.parse(config);
+        }
+
+        var client = config.protocol === "https:" || (typeof(config) === "string" && config.startsWith("https")) ? require("https") : require("http");
+
+        try{
+          client.get(config, function (response) {
+            // Continuously update stream with data
+            var body = "";
+            response.on("data", function (d) {
+              body += d;
+            });
+            response.on("end", function () {
+              try{
+                dictionary = JSON.parse(body);
+              }catch(e){
+                console.warn("Error parsing nightwatch extra dictionary. " + JSON.stringify(body) + ". " + JSON.stringify(e));
+              }
+            });
+            response.on("error", function (e) {
+              console.warn("Error loading error dictionary. " + JSON.stringify(config) + ". " + JSON.stringify(e));
+            });
+          }).on("error", function(e){
+            console.warn("Error loading error dictionary. " + JSON.stringify(config) + ". " + JSON.stringify(e));
+          });
+        }catch(e){
+          console.warn("Error loading error dictionary. " + JSON.stringify(config) + ". " + JSON.stringify(e));
+        }
       }
-
-      var client = config.protocol === "https:" || (typeof(config) === "string" && config.startsWith("https")) ? require("https") : require("http");
-
-      client.get(config, function (response) {
-        // Continuously update stream with data
-        var body = "";
-        response.on("data", function (d) {
-          body += d;
-        });
-        response.on("end", function () {
-          try{
-            dictionary = JSON.parse(body);
-          }catch(e){
-            console.warn("Error parsing nightwatch extra dictionary. " + JSON.stringify(body));
-          }
-        });
-        response.on("error", function (e) {
-          console.warn("Error loading error dictionary. " + JSON.stringify(e));
-        });
-      }).on("error", function(e){
-        console.warn("Error loading error dictionary. " + JSON.stringify(e));
-      });
     }
   },
   format: function (error) {
     let ret = error;
     if(dictionary){
-      Object.entries(dictionary).forEach(([key, value]) => {
+      for(var key in dictionary){
+        let value = dictionary[key];
         let regex = new RegExp(key);
         if(error.match(regex)){
           ret = error.replace(regex, value);
         }
-      });
+      }
     }
     return ret;
   }

--- a/src/errorDictionary.js
+++ b/src/errorDictionary.js
@@ -1,0 +1,38 @@
+
+var http = require('http');
+var https = require('https');
+let dictionary;
+
+module.exports = {
+  init: function (config) {
+    if(!dictionary && config){
+
+      var client = config.protocol === 'https:' ? https : http;
+
+      client.get(config, function(response) {
+          // Continuously update stream with data
+          var body = '';
+          response.on('data', function(d) {
+              body += d;
+          });
+          response.on('end', function() {
+              dictionary = JSON.parse(body);
+          });
+          response.on('error', function(e){
+            console.log(e);
+          });
+      });
+    }
+  },
+  format: function (error) {
+    let ret = error;
+    if(dictionary){
+      Object.entries(dictionary).forEach(([key, value]) => {
+        if(error.match(new RegExp(key))){
+          ret += ". " + value;
+        }
+      });
+    }
+    return ret;
+  }
+}

--- a/src/errorDictionary.js
+++ b/src/errorDictionary.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import request from "request";
+import logger from "./util/logger";
 
 let dictionary;
 
@@ -11,7 +12,7 @@ module.exports = {
       if(typeof(config) === 'string' && fs.existsSync(config)){
         // error if directory
         if(!fs.lstatSync(config).isFile()){
-          console.warn("Error reading nightwatch extra dictionary from [" + config + "]. Path must be a file!");
+          logger.warn("Error reading nightwatch extra dictionary from [" + config + "]. Path must be a file!");
           return;
         }
         let content = fs.readFileSync(config, 'utf8');
@@ -19,7 +20,7 @@ module.exports = {
           dictionary = JSON.parse(content);
         }catch(e){
           // error if JSON parse fails
-          console.warn("Error parsing nightwatch extra dictionary from file [" + config + "]. File Content: [" + content + "]. " + e + ". Contents must be a valid json object with key/value pairs.");
+          logger.warn("Error parsing nightwatch extra dictionary from file [" + config + "]. File Content: [" + content + "]. " + e + ". Contents must be a valid json object with key/value pairs.");
         }
       }else{
 
@@ -29,20 +30,20 @@ module.exports = {
             config = JSON.parse(config);
           }catch(e){
             // error if invalid
-            console.warn("Error loading error dictionary from [" + config + "]. " + e + ". Config should be a valid file string, url string, or a url object accpted by https://github.com/request/request#requestoptions-callback.");
+            logger.warn("Error loading error dictionary from [" + config + "]. " + e + ". Config should be a valid file string, url string, or a url object accpted by https://github.com/request/request#requestoptions-callback.");
             return;
           }
         }
 
         request(config, function (error, response, body) {
           if(error){
-            console.warn("Error loading error dictionary from [" + JSON.stringify(config) + "]. " + error + ". Config should be a valid file string, url string, or a url object accpted by https://github.com/request/request#requestoptions-callback.");
+            logger.warn("Error loading error dictionary from [" + JSON.stringify(config) + "]. " + error + ". Config should be a valid file string, url string, or a url object accpted by https://github.com/request/request#requestoptions-callback.");
             return;
           }
           try{
             dictionary = JSON.parse(body);
           }catch(e){
-            console.warn("Error parsing nightwatch extra dictionary. Dictionary: [" + JSON.stringify(body) + "]. " + e + ". Contents must be a valid json object with key/value pairs.");
+            logger.warn("Error parsing nightwatch extra dictionary. Dictionary: [" + JSON.stringify(body) + "]. " + e + ". Contents must be a valid json object with key/value pairs.");
           }
         });
       }

--- a/src/errorDictionary.js
+++ b/src/errorDictionary.js
@@ -1,28 +1,34 @@
 
-var http = require('http');
-var https = require('https');
 let dictionary;
 
 module.exports = {
   init: function (config) {
     if(!dictionary && config){
 
-      var client = config.protocol === 'https:' ? https : http;
+      if(typeof(config) === 'string' && config.startsWith("{")){
+        config = JSON.parse(config);
+      }
+
+      var client = config.protocol === "https:" || (typeof(config) === "string" && config.startsWith("https")) ? require("https") : require("http");
 
       client.get(config, function (response) {
         // Continuously update stream with data
-        var body = '';
-        response.on('data', function (d) {
+        var body = "";
+        response.on("data", function (d) {
           body += d;
         });
-        response.on('end', function () {
-          dictionary = JSON.parse(body);
+        response.on("end", function () {
+          try{
+            dictionary = JSON.parse(body);
+          }catch(e){
+            console.warn("Error parsing nightwatch extra dictionary. " + JSON.stringify(body));
+          }
         });
-        response.on('error', function (e) {
-          console.log("Error loading error dictionary. " + JSON.stringify(e));
+        response.on("error", function (e) {
+          console.warn("Error loading error dictionary. " + JSON.stringify(e));
         });
-      }).on('error', function(e){
-        console.log("Error loading error dictionary. " + JSON.stringify(e));
+      }).on("error", function(e){
+        console.warn("Error loading error dictionary. " + JSON.stringify(e));
       });
     }
   },

--- a/src/settings.js
+++ b/src/settings.js
@@ -105,6 +105,10 @@ export default {
   JS_SEEN_MAX: 3,
   COMMAND_MAX_TIMEOUT: timeoutValue,
   JS_MAX_TIMEOUT: jsTimeoutValue,
+  SERVER_ERROR: 'SERVER_ERROR',
+  SELECTOR_NOT_FOUND: 'SELECTOR_NOT_FOUND',
+  SELECTOR_NOT_VISIBLE: 'SELECTOR_NOT_VISIBLE',
+  SELENIUM_ERROR: 'SELENIUM_ERROR',
 
   // true if test is launched by a specific runner other than nightwatch, such as magellan
   isWorker: !!argv.worker,

--- a/src/settings.js
+++ b/src/settings.js
@@ -109,6 +109,7 @@ export default {
   SELECTOR_NOT_FOUND: 'SELECTOR_NOT_FOUND',
   SELECTOR_NOT_VISIBLE: 'SELECTOR_NOT_VISIBLE',
   SELENIUM_ERROR: 'SELENIUM_ERROR',
+  BAD_GATEWAY: 'BAD_GATEWAY',
 
   // true if test is launched by a specific runner other than nightwatch, such as magellan
   isWorker: !!argv.worker,

--- a/src/settings.js
+++ b/src/settings.js
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import yargs from "yargs";
 import logger from "./util/logger";
+import errorDictionary from "./errorDictionary";
 
 const DEFAULT_MAX_TIMEOUT = 60000;
 const JS_MAX_TIMEOUT_OFFSET = 5000;
@@ -61,6 +62,7 @@ const getConfig = function () {
     } else {
       logger.log(`nightwatch-magellan has found nightwatch configuration at ${ configPath}`);
       const nightwatchConfig = JSON.parse(data);
+      errorDictionary.init(process.env.NIGHTWATCH_ERROR_DICTIONARY || nightwatchConfig.test_settings.default.errorDictionary);
       return {
         nightwatchConfig
       };
@@ -105,11 +107,6 @@ export default {
   JS_SEEN_MAX: 3,
   COMMAND_MAX_TIMEOUT: timeoutValue,
   JS_MAX_TIMEOUT: jsTimeoutValue,
-  SERVER_ERROR: 'SERVER_ERROR',
-  SELECTOR_NOT_FOUND: 'SELECTOR_NOT_FOUND',
-  SELECTOR_NOT_VISIBLE: 'SELECTOR_NOT_VISIBLE',
-  SELENIUM_ERROR: 'SELENIUM_ERROR',
-  BAD_GATEWAY: 'BAD_GATEWAY',
 
   // true if test is launched by a specific runner other than nightwatch, such as magellan
   isWorker: !!argv.worker,

--- a/tests/conf/nightwatch.json
+++ b/tests/conf/nightwatch.json
@@ -43,7 +43,8 @@
           "ipad"
         ],
         "resultUrlPrefix": "https://saucelabs.com/tests/"
-      }
+      },
+      "max_timeout": 1000
     },
     "phantomjs": {
       "desiredCapabilities": {

--- a/tests/src/base-assertion.test.js
+++ b/tests/src/base-assertion.test.js
@@ -282,7 +282,7 @@ describe("Base assertion", () => {
 
         clientMock.assertion = (result, actual, expected, message, abortonfail) => {
           expect(result).to.equal(false);
-          expect(actual).to.equal(undefined);
+          expect(actual).to.equal('[selenium error]');
           expect(expected).to.equal(undefined);
           expect(abortonfail).to.equal(true);
         };
@@ -374,7 +374,7 @@ describe("Base assertion", () => {
 
         clientMock.assertion = (result, actual, expected, message, abortonfail) => {
           expect(result).to.equal(false);
-          expect(actual).to.equal(undefined);
+          expect(actual).to.equal('[selenium error]');
           expect(expected).to.equal(undefined);
           expect(abortonfail).to.equal(true);
         };
@@ -475,6 +475,84 @@ describe("Base assertion", () => {
         expect(baseAssertion.seenCount).to.equal(3);
         expect(expected).to.equal("some_fake_value");
         expect(value).to.equal("magellan_selector_2f38e1cf");
+        done();
+      };
+      baseAssertion.decide();
+      baseAssertion.checkConditions();
+    });
+
+    it("Fail with not found", (done) => {
+      clientMock.api.execute = (fn, args, callback) => {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 0,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      baseAssertion = new BaseAssertion(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseAssertion.seenCount = 0;
+      baseAssertion.expected = "some_fake_value";
+      baseAssertion.startTime = (new Date()).getTime();
+      baseAssertion.fail = (value, expected) => {
+        expect(baseAssertion.seenCount).to.equal(0);
+        expect(expected).to.equal("some_fake_value");
+        expect(value).to.equal("[not found]");
+        done();
+      };
+      baseAssertion.decide();
+      baseAssertion.checkConditions();
+    });
+
+    it("Fail with not visible", (done) => {
+      clientMock.api.execute = (fn, args, callback) => {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 1,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      baseAssertion = new BaseAssertion(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseAssertion.seenCount = 0;
+      baseAssertion.expected = "some_fake_value";
+      baseAssertion.startTime = (new Date()).getTime();
+      baseAssertion.fail = (value, expected) => {
+        expect(baseAssertion.seenCount).to.equal(0);
+        expect(expected).to.equal("some_fake_value");
+        expect(value).to.equal("[not visible]");
         done();
       };
       baseAssertion.decide();

--- a/tests/src/base-assertion.test.js
+++ b/tests/src/base-assertion.test.js
@@ -481,6 +481,51 @@ describe("Base assertion", () => {
       baseAssertion.checkConditions();
     });
 
+    it("Fail with Bad Gateway", (done) => {
+      clientMock.api.execute = (fn, args, callback) => {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 0,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      clientMock.api.title = (callback) => {
+        callback({
+          value:"Bad Gateway"
+        })
+      }
+
+      baseAssertion = new BaseAssertion(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseAssertion.seenCount = 0;
+      baseAssertion.expected = "some_fake_value";
+      baseAssertion.startTime = (new Date()).getTime();
+      baseAssertion.fail = (value, expected) => {
+        expect(baseAssertion.seenCount).to.equal(0);
+        expect(expected).to.equal("some_fake_value");
+        expect(value).to.equal("[bad gateway]");
+        done();
+      };
+      baseAssertion.decide();
+      baseAssertion.checkConditions();
+    });
+
     it("Fail with not found", (done) => {
       clientMock.api.execute = (fn, args, callback) => {
         callback({
@@ -503,6 +548,12 @@ describe("Base assertion", () => {
           status: 0
         });
       };
+
+      clientMock.api.title = (callback) => {
+        callback({
+          value:"good"
+        })
+      }
 
       baseAssertion = new BaseAssertion(clientMock, {
         syncModeBrowserList: ["chrome:55", "iphone"]

--- a/tests/src/base-command.test.js
+++ b/tests/src/base-command.test.js
@@ -284,8 +284,8 @@ describe("Base command", () => {
 
         clientMock.assertion = function (result, actual, expected, message, abortonfail) {
           expect(result).to.equal(false);
-          expect(actual).to.equal("not visible");
-          expect(expected).to.equal("visible");
+          expect(actual).to.equal("[selenium error]");
+          expect(expected).to.equal("[visible]");
           expect(abortonfail).to.equal(true);
         };
 
@@ -375,8 +375,8 @@ describe("Base command", () => {
 
         clientMock.assertion = function (result, actual, expected, message, abortonfail) {
           expect(result).to.equal(false);
-          expect(actual).to.equal("not visible");
-          expect(expected).to.equal("visible");
+          expect(actual).to.equal("[selenium error]");
+          expect(expected).to.equal("[visible]");
           expect(abortonfail).to.equal(true);
         };
 

--- a/tests/src/base-command.test.js
+++ b/tests/src/base-command.test.js
@@ -475,5 +475,129 @@ describe("Base command", () => {
       baseCommand.decide();
       baseCommand.checkConditions();
     });
+
+
+    it("Fail with Bad Gateway", (done) => {
+      clientMock.api.execute = function (fn, args, callback) {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 0,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      clientMock.api.title = (callback) => {
+        callback({
+          value:"Bad Gateway"
+        })
+      }
+
+      baseCommand = new BaseCommand(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseCommand.seenCount = 0;
+      baseCommand.startTime = (new Date()).getTime();
+      baseCommand.fail = function (value) {
+        expect(baseCommand.seenCount).to.equal(0);
+        expect(value).to.equal("[bad gateway]");
+        done();
+      };
+      baseCommand.decide();
+      baseCommand.checkConditions();
+    });
+
+    it("Fail with not found", (done) => {
+      clientMock.api.execute = function (fn, args, callback) {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 0,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      clientMock.api.title = (callback) => {
+        callback({
+          value:"good"
+        })
+      }
+
+      baseCommand = new BaseCommand(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseCommand.seenCount = 0;
+      baseCommand.startTime = (new Date()).getTime();
+      baseCommand.fail = function (value) {
+        expect(baseCommand.seenCount).to.equal(0);
+        expect(value).to.equal("[not found]");
+        done();
+      };
+      baseCommand.decide();
+      baseCommand.checkConditions();
+    });
+
+    it("Fail with not visible", (done) => {
+      clientMock.api.execute = function (fn, args, callback) {
+        callback({
+          state: 'success',
+          sessionId: '60c692d2-7b53-4d43-a340-8d6133af13a8',
+          hCode: 1895546026,
+          value:
+          {
+            isVisible: false,
+            isVisibleStrict: false,
+            seens: 0,
+            selectorLength: 1,
+            selectorVisibleLength: 0,
+            value: {
+              sel: '#testDiv2',
+              value: null
+            }
+          },
+          class: 'org.openqa.selenium.remote.Response',
+          status: 0
+        });
+      };
+
+      baseCommand = new BaseCommand(clientMock, {
+        syncModeBrowserList: ["chrome:55", "iphone"]
+      });
+      baseCommand.seenCount = 0;
+      baseCommand.startTime = (new Date()).getTime();
+      baseCommand.fail = function (value) {
+        expect(baseCommand.seenCount).to.equal(0);
+        expect(value).to.equal("[not visible]");
+        done();
+      };
+      baseCommand.decide();
+      baseCommand.checkConditions();
+    });
   });
 });

--- a/tests/src/commands/getEl.test.js
+++ b/tests/src/commands/getEl.test.js
@@ -134,8 +134,8 @@ describe("GetEl", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getEl = new GetEl(clientMock, {
@@ -163,8 +163,8 @@ describe("GetEl", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getEl = new GetEl(clientMock);

--- a/tests/src/commands/getElValue.test.js
+++ b/tests/src/commands/getElValue.test.js
@@ -127,8 +127,8 @@ describe("GetElValue", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getElValue = new GetElValue(clientMock, {
@@ -156,8 +156,8 @@ describe("GetElValue", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getElValue = new GetElValue(clientMock);

--- a/tests/src/commands/getEls.test.js
+++ b/tests/src/commands/getEls.test.js
@@ -138,8 +138,8 @@ describe("GetEls", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getEls = new GetEls(clientMock, {
@@ -167,8 +167,8 @@ describe("GetEls", () => {
 
       clientMock.assertion = function (result, actual, expected, message, abortonfail) {
         expect(result).to.equal(false);
-        expect(actual).to.equal("not visible");
-        expect(expected).to.equal("visible");
+        expect(actual).to.equal("[selenium error]");
+        expect(expected).to.equal("[visible]");
       };
 
       getEls = new GetEls(clientMock);


### PR DESCRIPTION
Added error dictionary as well as logic to distinguish between:
1) Server/network connection error
2) Selector not found
3) Selector not visible

The dictionary source can either be a url string or url object (https://nodejs.org/api/http.html#http_http_request_options_callback). It can be set as env var NIGHTWATCH_ERROR_DICTIONARY or in nightwatch.json testSetting.default.errorDictionary

Example dictionary: https://gecgithub01.walmart.com/cahrens/test/blob/master/dictionary.json