### PR TITLE
Add tests for empty Edge inputs returning a value of null

### DIFF
--- a/src/assertions/elValueContains.js
+++ b/src/assertions/elValueContains.js
@@ -12,8 +12,15 @@ const ElValueContains = function (nightwatch = null, customizedSettings = null) 
 util.inherits(ElValueContains, BaseAssertion);
 
 ElValueContains.prototype.assert = function (actual, expected) {
+  if (actual === null) {
+    // Per the spec, we should get the input's value content *or* an empty string
+    // https://www.w3.org/TR/2010/WD-html5-20101019/the-input-element.html#attr-input-value
+    // Versions of Microsoft Edge (14) will return `null` for empty inputs, so we fix to adhere to the spec.
+    // For elements that *aren't* inputs, value would be `undefined`.
+    actual = "";
+  }
   if (expected === undefined
-    || !actual || actual.indexOf(expected) < 0
+    || actual === undefined || actual.indexOf(expected) < 0
     && !new RegExp(expected).exec(actual)) {
 
     this.fail({

--- a/src/assertions/elValueContains.js
+++ b/src/assertions/elValueContains.js
@@ -15,7 +15,8 @@ ElValueContains.prototype.assert = function (actual, expected) {
   if (actual === null) {
     // Per the spec, we should get the input's value content *or* an empty string
     // https://www.w3.org/TR/2010/WD-html5-20101019/the-input-element.html#attr-input-value
-    // Versions of Microsoft Edge (14) will return `null` for empty inputs, so we fix to adhere to the spec.
+    // Versions of Microsoft Edge (14) will return `null` for empty inputs,
+    // so we fix to adhere to the spec.
     // For elements that *aren't* inputs, value would be `undefined`.
     actual = "";
   }

--- a/tests/src/assertions/elValueContains.text.js
+++ b/tests/src/assertions/elValueContains.text.js
@@ -155,6 +155,16 @@ describe("ElValueContains", () => {
 
       expect(called).to.equal(true);
     });
+
+    it("passes when expected and actual are both empty strings (Edge)", () => {
+      elValueContains = new ElValueContains(clientMock);
+      let called = false;
+
+      elValueContains.pass = () => { called = true; };
+      elValueContains.assert("", "");
+
+      expect(called).to.equal(true);
+    });
   });
   
 });

--- a/tests/src/assertions/elValueContains.text.js
+++ b/tests/src/assertions/elValueContains.text.js
@@ -138,4 +138,22 @@ describe("ElValueContains", () => {
       elValueContains.command("[name='q']", "invalid_fake_textual_message");
     });
   });
+
+  describe("assert", () => {
+    it("passes when expected and actual are empty strings", () => {
+      elValueContains = new ElValueContains(clientMock);
+      let called = false;
+
+      elValueContains.pass = () => { called = true; };
+      elValueContains.assert("", "");
+
+      expect(called).to.equal(true);
+    });
+
+    it("handles actual being null (Edge)", () => {
+      elValueContains = new ElValueContains(clientMock);
+
+      expect(() => elValueContains.assert(null, "expected")).to.not.throw();
+    });
+  });
 });

--- a/tests/src/assertions/elValueContains.text.js
+++ b/tests/src/assertions/elValueContains.text.js
@@ -140,20 +140,21 @@ describe("ElValueContains", () => {
   });
 
   describe("assert", () => {
-    it("passes when expected and actual are empty strings", () => {
-      elValueContains = new ElValueContains(clientMock);
-      let called = false;
-
-      elValueContains.pass = () => { called = true; };
-      elValueContains.assert("", "");
-
-      expect(called).to.equal(true);
-    });
-
     it("handles actual being null (Edge)", () => {
       elValueContains = new ElValueContains(clientMock);
 
       expect(() => elValueContains.assert(null, "expected")).to.not.throw();
     });
+
+    it("passes when expected is an empty string but actual is null (Edge)", () => {
+      elValueContains = new ElValueContains(clientMock);
+      let called = false;
+
+      elValueContains.pass = () => { called = true; };
+      elValueContains.assert(null, "");
+
+      expect(called).to.equal(true);
+    });
   });
+  
 });


### PR DESCRIPTION
## Background
Microsoft Edge was returning `null` for an empty inputs `value` property. This led to errors like:
```
08:26:49 Running: Assert blank fields ...
08:26:50 ✖ TypeError: Cannot read property 'indexOf' of null
```

A fix to avoid this error was added by https://github.com/TestArmada/nightwatch-extra/pull/108/files.

I added a test for this https://github.com/TestArmada/nightwatch-extra/pull/120/files#diff-e041bab4fb9b10009bf9334cde429064R143

The problem with this fix is is doing `client.elValueContains(selector, "")` on an empty input will now **fail**

```
21:59:04 04:59:00 FAILED:  1 assertions failed (898ms)
21:59:04 04:59:00  _________________________________________________
21:59:04 04:59:00  TEST FAILURE:  1 assertions failed, 0 passed. (22.315s)
21:59:04 04:59:00  ✖ create
21:59:04 04:59:00    - Input project info (898ms)
21:59:04 04:59:00    Testing if selector <#projectName> has value <> after 581 milliseconds  -> Assertion failure   - expected "" but got: ""
```

I'm feel like that is incorrect and added the test https://github.com/TestArmada/nightwatch-extra/pull/120/files#diff-e041bab4fb9b10009bf9334cde429064R159 to make sure it passes.

## Fixing Edge

For browsers returning `null` for empty inputs, we have no way to consistently test empty fields (since it could be `null` *or* `""`).

We fix this by doing a null check and if true, fixing the `actual` value to what it should be via the spec https://github.com/TestArmada/nightwatch-extra/pull/120/files#diff-ffe0c41e69cbb1693549935cd322fd51R15

and testing it with https://github.com/TestArmada/nightwatch-extra/pull/120/files#diff-e041bab4fb9b10009bf9334cde429064R149

I'd love some feedback on if I'm missing any edge cases or browser quirks. For non-input elements, value will be `undefined` so I don't see any false positives that way. Any other cases where the `value` of an input would be `null`?
