### PR TITLE
Add runAppiumCommand

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -151,6 +151,11 @@ The mobile command/assertion set follows the same convention of their desktop co
     <td>swipe screen starting from an element with given selector to point measured by vector (x, y)</td>
   </tr>
   <tr>
+    <td>swipeMobileElToEl(using, selector, using2, selector2, callback)</td>
+    <td>swipeMobileElToEl("accessibility id", "answer", "accessibility id", "question")</td>
+    <td>swipe screen starting from an element with given selector to another element with given selector</td>
+  </tr>
+  <tr>
     <td>swipeScreenTo(fx, fy, tx, ty, callback)</td>
     <td>swipeScreenTo(30, 400, 0, -100)</td>
     <td>swipe screen starting from given coordinate (fx,fy) to point measured by vector (x, y)</td>

--- a/docs/android.md
+++ b/docs/android.md
@@ -146,6 +146,11 @@ The mobile command/assertion set follows the same convention of their desktop co
     <td>hide/dismiss keyboard</td>
   </tr>
   <tr>
+    <td>runAppiumCommand(options, callback)</td>
+    <td>runAppiumCommand({path: 'appium/device/current_activity', method: 'GET'}, function(result) { console.log('Activity = ' + result) })</td>
+    <td>directly hit an Appium API endpoint and return result in callback</td>
+  </tr>
+  <tr>
     <td>swipeMobileElTo(using, selector, x, y, callback)</td>
     <td>swipeMobileElTo("accessibility id", "search", 0, -100)</td>
     <td>swipe screen starting from an element with given selector to point measured by vector (x, y)</td>

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -145,6 +145,11 @@ The mobile command/assertion set follows the same convention of their desktop co
     <td>swipe screen starting from an element with given selector to point measured by vector (x, y)</td>
   </tr>
   <tr>
+    <td>swipeMobileElToEl(using, selector, using2, selector2, callback)</td>
+    <td>swipeMobileElToEl("accessibility id", "answer", "accessibility id", "question")</td>
+    <td>swipe screen starting from an element with given selector to another element with given selector</td>
+  </tr>
+  <tr>
     <td>swipeScreenTo(fx, fy, tx, ty, callback)</td>
     <td>swipeScreenTo(30, 400, 0, -100)</td>
     <td>swipe screen starting from given coordinate (fx,fy) to point measured by vector (x, y)</td>

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -140,6 +140,11 @@ The mobile command/assertion set follows the same convention of their desktop co
     <td>return element's value in the callback with given selector</td>
   </tr>
   <tr>
+    <td>runAppiumCommand(options, callback)</td>
+    <td>runAppiumCommand({path: 'appium/device/current_activity', method: 'GET'}, function(result) { console.log('Activity = ' + result) })</td>
+    <td>directly hit an Appium API endpoint and return result in callback</td>
+  </tr>
+  <tr>
     <td>swipeMobileElTo(using, selector, x, y, callback)</td>
     <td>swipeMobileElTo("accessibility id", "search", 0, -100)</td>
     <td>swipe screen starting from an element with given selector to point measured by vector (x, y)</td>

--- a/docs/web.md
+++ b/docs/web.md
@@ -56,18 +56,6 @@ All commands and assertions are fully compatible with nightwatchjs page object.
     <td>waitForElementPresent(".submitButton") or waitForElementVisible(".submitButton")</td>
   </tr>
   <tr>
-    <td>moveToEl(css selector, xoffset, yoffset)</td>
-    <td>moveToEl(".submitButton", 10, 10)</td>
-    <td>move cursor to a given element</td>
-    <td>moveToElement(".submitButton", 10, 10)</td>
-  </tr>
-  <tr>
-    <td>setElValue(css selector, value)</td>
-    <td>setElValue(".username", "testarmada")</td>
-    <td>set value to an element after it is verified visible</td>
-    <td>setValue(".username", "testarmada")</td>
-  </tr>
-  <tr>
     <td>getElValue(css selector, callback)</td>
     <td>getElValue(".user-profile", function(profile){// use profile here})</td>
     <td>get value of an element after it is verified visible</td>
@@ -80,16 +68,27 @@ All commands and assertions are fully compatible with nightwatchjs page object.
     <td>elements("css selector", ".state-options", function(stats){// use stats here})</td>
   </tr>
   <tr>
+    <td>moveToEl(css selector, xoffset, yoffset)</td>
+    <td>moveToEl(".submitButton", 10, 10)</td>
+    <td>move cursor to a given element</td>
+    <td>moveToElement(".submitButton", 10, 10)</td>
+  </tr>
+  <tr>
+    <td>runAppiumCommand(options, callback)</td>
+    <td>runAppiumCommand({path: 'appium/device/current_activity', method: 'GET'}, function(result) { console.log('Activity = ' + result) })</td>
+    <td>directly hit an Appium API endpoint and return result in callback</td>
+  </tr>
+  <tr>
+    <td>setElValue(css selector, value)</td>
+    <td>setElValue(".username", "testarmada")</td>
+    <td>set value to an element after it is verified visible</td>
+    <td>setValue(".username", "testarmada")</td>
+  </tr>
+  <tr>
     <td>setMaskedElValue(css selector, value, [fieldLength])</td>
     <td>setMaskedElValue(".phone-number", "123456789")</td>
     <td>set value to masked element like credit card number and phone number input</td>
     <td>(no nightwatch equivalent)</td>
-  </tr>
-   <tr>
-    <td>waitForElNotPresent(css selector)</td>
-    <td>waitForElNotPresent(".submitButton")</td>
-    <td>wait for an element to be not visible</td>
-    <td>waitForElementNotPresent(".submitButton")</td>
   </tr>
   <tr>
     <td>takeElScreenshot(css selector, filename)</td>
@@ -102,6 +101,12 @@ All commands and assertions are fully compatible with nightwatchjs page object.
     <td>takeScreenhot("page")</td>
     <td>take screen shot for current page</td>
     <td>screenshot()</td>
+  </tr>
+   <tr>
+    <td>waitForElNotPresent(css selector)</td>
+    <td>waitForElNotPresent(".submitButton")</td>
+    <td>wait for an element to be not visible</td>
+    <td>waitForElementNotPresent(".submitButton")</td>
   </tr>
 </table>
 

--- a/src/commands/mobile/runAppiumCommand.js
+++ b/src/commands/mobile/runAppiumCommand.js
@@ -1,0 +1,88 @@
+/**
+  Use http://appium.io/docs/en/about-appium/api/ to find path, method, and data (for POST) params
+  Example usage:
+  client.runAppiumCommand(
+  {
+    path: 'appium/device/current_activity',
+    // "/session/${sessionId}/" is added by runAppiumCommand, so don't include it in the path
+    method: "GET"
+  }, function (result) {
+    console.log('Current Activity is: ' + result)
+  }
+);*/
+
+import util from "util";
+import BaseCommand from "../../base-mobile-command";
+import settings from "../../settings";
+
+const MAX_TIMEOUT = settings.COMMAND_MAX_TIMEOUT;
+const WAIT_INTERVAL = settings.WAIT_INTERVAL;
+
+const RunAppiumCommand = function (nightwatch = null) {
+  BaseCommand.call(this, nightwatch);
+  this.cmd = "runappiumcommand";
+};
+
+util.inherits(RunAppiumCommand, BaseCommand);
+
+RunAppiumCommand.prototype.do = function (value) {
+  this.pass({actual: value});
+};
+
+/* eslint-disable no-magic-numbers */
+RunAppiumCommand.prototype.checkConditions = function () {
+  const self = this;
+
+  self.protocol(self.options, (result) => {
+    if (result.status === 0) {
+      // successful
+      self.seenCount += 1;
+    } else if (result.status === -1 &&
+      result.errorStatus === 13) {
+      // method not implemented, fail immediately
+      self.fail({
+        code: settings.FAILURE_REASONS.BUILTIN_COMMAND_NOT_SUPPORTED,
+        message: self.failureMessage
+      });
+    }
+
+    const elapsed = (new Date()).getTime() - self.startTime;
+    if (self.seenCount >= 1 || elapsed > MAX_TIMEOUT) {
+      if (self.seenCount >= 1) {
+        const elapse = (new Date()).getTime();
+        self.time.executeAsyncTime = elapse - self.startTime;
+        self.time.seleniumCallTime = 0;
+        self.do(result.value);
+      } else {
+        self.fail({
+          code: settings.FAILURE_REASONS.BUILTIN_COMMAND_TIMEOUT,
+          message: self.failureMessage
+        });
+      }
+    } else {
+      setTimeout(self.checkConditions, WAIT_INTERVAL);
+    }
+  });
+};
+
+RunAppiumCommand.prototype.command = function (options, cb) {
+  this.options = options;
+  // Prepend the sessionId to the path:
+  this.options.path = `/session/${this.client.sessionId}/${this.options.path}`;
+  this.cb = cb;
+
+  this.successMessage =
+    `Successfully hit ${this.options.path} with ${this.options.method} after %d milliseconds`;
+  this.failureMessage =
+    `Failed to hit ${this.options.path} with ${this.options.method} after %d milliseconds`;
+
+  this.startTime = (new Date()).getTime();
+
+  // Track how many times selector is successfully checked by /element protocol
+  this.seenCount = 0;
+  this.checkConditions();
+
+  return this;
+};
+
+module.exports = RunAppiumCommand;

--- a/src/commands/mobile/swipeMobileElToEl.js
+++ b/src/commands/mobile/swipeMobileElToEl.js
@@ -1,0 +1,71 @@
+import util from "util";
+import BaseCommand from "../../base-mobile-command";
+import settings from "../../settings";
+
+const SwipeMobileElToEl = function (nightwatch = null) {
+  BaseCommand.call(this, nightwatch);
+  this.cmd = "swipemobileeltoel";
+};
+
+util.inherits(SwipeMobileElToEl, BaseCommand);
+
+
+SwipeMobileElToEl.prototype.do = function (value) {
+  const self = this;
+  const client = self.client.api;
+
+  // Get location of element 2, then drag element1 to element2
+  client.getMobileEl(self.using2, self.selector2, function (result) {
+    const elementId2 = result.ELEMENT;
+
+    const options = {
+      path: `/session/${self.client.sessionId}/touch/perform`,
+      method: "POST",
+      data: {
+        "actions": [
+          {"action": "press", "options": {"element": value.ELEMENT}},
+          {"action": "wait", "options": {"ms": 800}},
+          {"action": "moveTo", "options": {'element': elementId2}},
+          {"action": "release", "options": {}}]
+      }
+    };
+
+    self.protocol(options, (result) => {
+      if (result.status === 0) {
+        self.pass({
+          actual: result.value
+        });
+      } else {
+        self.fail({
+          code: settings.FAILURE_REASONS.BUILTIN_ELEMENT_NOT_OPERABLE,
+          message: self.failureMessage
+        });
+      }
+    });
+  });
+}
+;
+
+/*eslint max-params:["error", 5] */
+SwipeMobileElToEl.prototype.command = function (using, selector, using2, selector2, cb) {
+  this.selector = selector;
+  this.using = using;
+  this.selector2 = selector2;
+  this.using2 = using2;
+  this.cb = cb;
+
+  this.successMessage = `Selector '${this.using}:${this.selector}' `
+    + `was swiped to selector '${this.using2}:${this.selector2}' after %d milliseconds.`;
+  this.failureMessage = `Selector '${this.using}:${this.selector}' `
+    + `was not swiped to selector '${this.using2}:${this.selector2}' after %d milliseconds.`;
+
+  this.startTime = (new Date()).getTime();
+
+  // Track how many times selector is successfully checked by /element protocol
+  this.seenCount = 0;
+  this.checkConditions();
+
+  return this;
+};
+
+module.exports = SwipeMobileElToEl;


### PR DESCRIPTION
Use case: 
Sometimes we directly want to hit the Appium API for debugging or testing a future custom command. Rather than writing a new custom command each time, this command allows us to pass the API options on the fly.