### PR TITLE
Adding The Ability to Pass More Configurations to StartActivity

### DIFF
--- a/src/commands/mobile/startActivity.js
+++ b/src/commands/mobile/startActivity.js
@@ -23,10 +23,7 @@ StartActivity.prototype.checkConditions = function () {
   const options = {
     path: `/session/${this.client.sessionId}/appium/device/start_activity`,
     method: "POST",
-    data: {
-      appPackage: this.appPackage,
-      appActivity: this.appActivity
-    }
+    data: this.app
   };
 
   self.protocol(options, (result) => {
@@ -63,6 +60,7 @@ StartActivity.prototype.checkConditions = function () {
 };
 
 StartActivity.prototype.command = function (app, cb) {
+  this.app = app;
   this.appPackage = app.appPackage;
   this.appActivity = app.appActivity;
   this.cb = cb;


### PR DESCRIPTION
**What does this do?**
This PR allows for StartActivity to take in more appium configurations than just appPackage and appActivity. 

With these changes, the StartActivity can take in every capability supported by appium, outlined here: http://appium.io/docs/en/commands/device/activity/start-activity/

**Why is this needed?**
For testing adaptability. Some tests may require an activity to be started multiple times with different configurations. The ability to pass intent into this method also opens up many possibilities and doors. 