### PR TITLE
Update dependencies with known vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,9 @@ env:
   - TIER_1_2_BROWSERS=microsoftedge_14_Windows_10_Desktop,safari_10_OS_X_10_11_Desktop,safari_9_OS_X_10_11_Desktop,IE_11_Windows_10_Desktop,IE_10_Windows_2012_Desktop,firefox_54_Windows_2012_R2_Desktop
 
 node_js:
-  - v9
-  - v8
-  - v7
-  - v6
+  - v14
+  - v12
+  - v10
 
 # Use container-based Travis infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "cli-color": "1.1.0",
-    "eslint": "^3.12.2",
+    "eslint": "^4.18.2",
     "eslint-config-walmart": "^1.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "jimp": "^0.2.27",
@@ -119,7 +119,7 @@
     "selenium-server": "^3.1.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
-    "codecov": "^1.0.1",
+    "codecov": "^3.7.1",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0"
   }


### PR DESCRIPTION
Codecov and Eslint have known vulnerabilities on the versions being used. These changes bring us to safe versions.